### PR TITLE
chore: migrate to gh-actions reusable workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,27 +2,12 @@ name: Publish to GitHub Packages
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*"]
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          registry-url: "https://npm.pkg.github.com"
-
-      - name: Publish
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: cboone/gh-actions/.github/workflows/npm-publish.yml@main
+    with:
+      node-version: "20"
+    secrets:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace inline npm publish steps with centralized `npm-publish.yml` reusable workflow from `cboone/gh-actions`

## Test plan

- [ ] Verify publish workflow triggers on tag push (validated by next release)