### PR TITLE
chore: pin gh-actions to v1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    uses: cboone/gh-actions/.github/workflows/npm-publish.yml@main
+    uses: cboone/gh-actions/.github/workflows/npm-publish.yml@v1
     with:
       node-version: "20"
     secrets:


### PR DESCRIPTION
## Summary

- Pin `cboone/gh-actions` references from `@main` to `@v1`

The gh-actions repo has been tagged with v1.0.0. Using the floating `@v1` tag ensures we automatically pick up non-breaking updates while maintaining stability.