### PR TITLE
chore: pin gh-actions to v2.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    uses: cboone/gh-actions/.github/workflows/npm-publish.yml@v1
+    uses: cboone/gh-actions/.github/workflows/npm-publish.yml@v2.1.2
     with:
       node-version: "20"
     secrets:


### PR DESCRIPTION
Pin all `cboone/gh-actions` workflow and action references from floating
tags (`@v1`, `@v2`) to the exact version `@v2.1.2`.

Part of the migration to exact-version-only tagging (cboone/gh-actions#25).
After all consuming repos are updated, the floating `v1` and `v2` tags
will be deleted from the gh-actions remote.